### PR TITLE
Minor fixes

### DIFF
--- a/multi-model-endpoint-tensorflow-cv.ipynb
+++ b/multi-model-endpoint-tensorflow-cv.ipynb
@@ -328,7 +328,7 @@
     "fig = plt.figure(figsize=(20, 5))\n",
     "for i in range(36):\n",
     "    ax = fig.add_subplot(3, 12, i+1, xticks=[], yticks=[])\n",
-    "    ax.imshow(np.squeeze(X_train[i].T))"
+    "    ax.imshow(np.squeeze(X_train[i]))"
    ]
   },
   {
@@ -857,7 +857,7 @@
    "source": [
     "fig, rows = plt.subplots(nrows=1, ncols=4, figsize=(224, 224))\n",
     "for row in rows:\n",
-    "    row.imshow(train_batches.next()[0][0].astype('int').T)\n",
+    "    row.imshow(train_batches.next()[0][0].astype('int'))\n",
     "    row.axis('off')\n",
     "plt.show()"
    ]
@@ -1458,7 +1458,7 @@
    },
    "outputs": [],
    "source": [
-    "predicted_label = np.argmax(y_pred)\n",
+    "predicted_label = np.argmax(y_pred['predictions'][0])\n",
     "print(f'Predicted Label: [{predicted_label}]')"
    ]
   }

--- a/multi-model-endpoint-tensorflow-cv.ipynb
+++ b/multi-model-endpoint-tensorflow-cv.ipynb
@@ -963,7 +963,7 @@
    "source": [
     "model_name = 'sign-language'\n",
     "\n",
-    "hyperparameters = {'epochs': 1}\n",
+    "hyperparameters = {'epochs': 5}\n",
     "estimator_parameters = {'entry_point':'sign_language_train.py',\n",
     "                        'instance_type': 'ml.m5.2xlarge',\n",
     "                        'instance_count': 1,\n",
@@ -1124,7 +1124,13 @@
    },
    "outputs": [],
    "source": [
-    "IMAGE_URI = '763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference:2.3.1-cpu-py37-ubuntu18.04'\n",
+    "from sagemaker.image_uris import retrieve\n",
+    "IMAGE_URI = retrieve(\n",
+    "    framework=\"tensorflow\",version=TF_FRAMEWORK_VERSION,\n",
+    "    image_scope='inference', \n",
+    "    instance_type='ml.m5.xlarge',\n",
+    "    region=sagemaker_session.boto_region_name)\n",
+    "\n",
     "model_data_prefix = f's3://{BUCKET}/{PREFIX}/mme/'"
    ]
   },
@@ -1461,6 +1467,22 @@
     "predicted_label = np.argmax(y_pred['predictions'][0])\n",
     "print(f'Predicted Label: [{predicted_label}]')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictor.delete_endpoint()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
*Issue #, I had problem trying to run the Notebook because of picture rendering *

*Description of changes:*
- Removed "Transpose" in order to allow proper picture rendering in Sagemaker Notebook
- Used retrieve to get container name instead of hard-coding it
- Fixed an issue with Test Model-2 Sign Language Classification for model evaluation
- Added a endpoint delete in the end to clean-up tehe environment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
